### PR TITLE
Benutze ttt_karma_max statt 1000

### DIFF
--- a/betting/lua/autorun/server/sv_karma_betting.lua
+++ b/betting/lua/autorun/server/sv_karma_betting.lua
@@ -292,8 +292,8 @@ if SERVER then
 							Color( 0, 255, 0, 255), " Karma!" )
 						
 						local newKarma = ply:GetLiveKarma() + karmaReturned
-						if newKarma > 1000 then
-							newKarma = 1000
+						if newKarma > GetConVar("ttt_karma_max"):GetInt() then
+							newKarma = GetConVar("ttt_karma_max"):GetInt()
 						end
 						ply:SetBaseKarma( newKarma )
 						ply:SetLiveKarma( newKarma )


### PR DESCRIPTION
Benutze variablen Wert `ttt_karma_max` statt feste `1000` bei Karmaverteilung.
Das hat den Vorteil, da nicht jeder das maximale Karma auf 1000 gelassen hat.
